### PR TITLE
sqltemplate: support pointer values

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,7 +6,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.18', '1.19']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/postgres.go
+++ b/postgres.go
@@ -49,35 +49,75 @@ func PostgresLiteral(v interface{}) (RawSQL, error) {
 		return v1, nil
 	case Identifier:
 		return RawSQL(`"` + strings.ReplaceAll(string(v1), `"`, `""`) + `"`), nil
+	case *bool:
+		if v1 == nil {
+			return RawSQL("NULL"), nil
+		}
+		return postgresLiteralBool(*v1), nil
 	case bool:
-		if v1 {
-			return RawSQL("TRUE"), nil
-		} else {
-			return RawSQL("FALSE"), nil
-		}
+		return postgresLiteralBool(v1), nil
 	case []byte:
+		if v1 == nil {
+			return RawSQL("NULL"), nil
+		}
 		return RawSQL(fmt.Sprintf("'\\x%X'", v1)), nil
+	case *float64:
+		if v1 == nil {
+			return RawSQL("NULL"), nil
+		}
+		return postgresLiteralFloat(*v1), nil
 	case float64:
-		if math.IsInf(v1, 1) {
-			return RawSQL("'Infinity'"), nil
+		return postgresLiteralFloat(v1), nil
+	case *int:
+		if v1 == nil {
+			return RawSQL("NULL"), nil
 		}
-		if math.IsInf(v1, -1) {
-			return RawSQL("'-Infinity'"), nil
-		}
-		if math.IsNaN(v1) {
-			return RawSQL("'NaN'"), nil
-		}
-		return RawSQL(fmt.Sprintf("%g", v1)), nil
+		return RawSQL(fmt.Sprintf("%d", *v1)), nil
 	case int:
 		return RawSQL(fmt.Sprintf("%d", v1)), nil
+	case *int64:
+		if v1 == nil {
+			return RawSQL("NULL"), nil
+		}
+		return RawSQL(fmt.Sprintf("%d", *v1)), nil
 	case int64:
 		return RawSQL(fmt.Sprintf("%d", v1)), nil
 	case nil:
 		return RawSQL("NULL"), nil
+	case *string:
+		if v1 == nil {
+			return RawSQL("NULL"), nil
+		}
+		return RawSQL(`'` + strings.ReplaceAll(*v1, `'`, `''`) + `'`), nil
 	case string:
 		return RawSQL(`'` + strings.ReplaceAll(v1, `'`, `''`) + `'`), nil
+	case *time.Time:
+		if v1 == nil {
+			return RawSQL("NULL"), nil
+		}
+		return RawSQL(`'` + (*v1).Format(time.RFC3339Nano) + `'`), nil
 	case time.Time:
 		return RawSQL(`'` + v1.Format(time.RFC3339Nano) + `'`), nil
 	}
 	return "", fmt.Errorf("unknown type %T", v)
+}
+
+func postgresLiteralBool(b bool) RawSQL {
+	if b {
+		return RawSQL("TRUE")
+	}
+	return RawSQL("FALSE")
+}
+
+func postgresLiteralFloat(f float64) RawSQL {
+	if math.IsInf(f, 1) {
+		return RawSQL("'Infinity'")
+	}
+	if math.IsInf(f, -1) {
+		return RawSQL("'-Infinity'")
+	}
+	if math.IsNaN(f) {
+		return RawSQL("'NaN'")
+	}
+	return RawSQL(fmt.Sprintf("%g", f))
 }

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -23,9 +23,21 @@ var postgresLiteralTests = []struct {
 	value:     "test string",
 	expectSQL: "'test string'",
 }, {
+	name:      "simple string pointer",
+	value:     newString("test string"),
+	expectSQL: "'test string'",
+}, {
 	name:      "string with quotes",
 	value:     "test 'string'",
 	expectSQL: "'test ''string'''",
+}, {
+	name:      "string with quotes pointer",
+	value:     newString("test 'string'"),
+	expectSQL: "'test ''string'''",
+}, {
+	name:      "nil string pointer",
+	value:     (*string)(nil),
+	expectSQL: "NULL",
 }, {
 	name:      "raw sql",
 	value:     RawSQL("'; DROP TABLE users;"),
@@ -43,41 +55,101 @@ var postgresLiteralTests = []struct {
 	value:     true,
 	expectSQL: `TRUE`,
 }, {
+	name:      "true pointer",
+	value:     newBool(true),
+	expectSQL: `TRUE`,
+}, {
 	name:      "false",
 	value:     false,
 	expectSQL: `FALSE`,
+}, {
+	name:      "false pointer",
+	value:     newBool(false),
+	expectSQL: `FALSE`,
+}, {
+	name:      "nil bool pointer",
+	value:     (*bool)(nil),
+	expectSQL: `NULL`,
 }, {
 	name:      "bytes",
 	value:     []byte("test"),
 	expectSQL: `'\x74657374'`,
 }, {
+	name:      "nil bytes",
+	value:     []byte(nil),
+	expectSQL: `NULL`,
+}, {
 	name:      "float",
 	value:     3.141592654,
+	expectSQL: `3.141592654`,
+}, {
+	name:      "float pointer",
+	value:     newFloat(3.141592654),
 	expectSQL: `3.141592654`,
 }, {
 	name:      "float Inf",
 	value:     math.Inf(0),
 	expectSQL: `'Infinity'`,
 }, {
+	name:      "float Inf pointer",
+	value:     newFloat(math.Inf(0)),
+	expectSQL: `'Infinity'`,
+}, {
 	name:      "float -Inf",
 	value:     math.Inf(-1),
+	expectSQL: `'-Infinity'`,
+}, {
+	name:      "float -Inf pointer",
+	value:     newFloat(math.Inf(-1)),
 	expectSQL: `'-Infinity'`,
 }, {
 	name:      "float NaN",
 	value:     math.NaN(),
 	expectSQL: `'NaN'`,
 }, {
+	name:      "float NaN pointer",
+	value:     newFloat(math.NaN()),
+	expectSQL: `'NaN'`,
+}, {
+	name:      "nil float pointer",
+	value:     (*float64)(nil),
+	expectSQL: `NULL`,
+}, {
 	name:      "int",
 	value:     0,
 	expectSQL: `0`,
+}, {
+	name:      "int pointer",
+	value:     newInt(0),
+	expectSQL: `0`,
+}, {
+	name:      "nil int pointer",
+	value:     (*int)(nil),
+	expectSQL: `NULL`,
 }, {
 	name:      "int64",
 	value:     int64(1e9),
 	expectSQL: `1000000000`,
 }, {
+	name:      "int64 pointer",
+	value:     newInt64(1e9),
+	expectSQL: `1000000000`,
+}, {
+	name:      "nil int64 pointer",
+	value:     (*int64)(nil),
+	expectSQL: `NULL`,
+}, {
 	name:      "time",
 	value:     time.Date(2020, time.February, 2, 12, 30, 45, 300001000, time.UTC),
 	expectSQL: `'2020-02-02T12:30:45.300001Z'`,
+}, {
+	name:      "time pointer",
+	value:     newTime(time.Date(2020, time.February, 2, 12, 30, 45, 300001000, time.UTC)),
+	expectSQL: `'2020-02-02T12:30:45.300001Z'`,
+}, {
+	name:      "niltime pointer",
+	value:     (*time.Time)(nil),
+	expectSQL: `NULL`,
 }, {
 	name: "valuer",
 	value: sql.NullTime{
@@ -114,4 +186,28 @@ func TestPostgresLiteralInTemplate(t *testing.T) {
 func TestPostgresLiteralUnknown(t *testing.T) {
 	_, err := PostgresLiteral(make(chan bool))
 	qt.Check(t, err, qt.ErrorMatches, `unknown type chan bool`)
+}
+
+func newBool(b bool) *bool {
+	return &b
+}
+
+func newFloat(f float64) *float64 {
+	return &f
+}
+
+func newInt(i int) *int {
+	return &i
+}
+
+func newInt64(i int64) *int64 {
+	return &i
+}
+
+func newString(s string) *string {
+	return &s
+}
+
+func newTime(t time.Time) *time.Time {
+	return &t
 }


### PR DESCRIPTION
Support encoding values that are pointers to the supported types. If the pointer is nil then a NULL literal is output, otherwise it is the literal produced by the dereferenced value.